### PR TITLE
Fixed dependency issue on 5.22

### DIFF
--- a/t/003_dsl2.t
+++ b/t/003_dsl2.t
@@ -67,7 +67,7 @@ package main;
 my $output = Hoge->output;
 ok $output and note $output;
 ok(Hoge->no_fk_output);
-ok(Hoge->translate_to('HTML')) or diag(Hoge->translator->error);
+ok(Hoge->translate_to('POD')) or diag(Hoge->translator->error);
 
 like(Fuga->output, qr/player/ms);
 unlike(Fuga->output, qr/user_purchase/ms);

--- a/t/003_dsl2.t
+++ b/t/003_dsl2.t
@@ -67,7 +67,7 @@ package main;
 my $output = Hoge->output;
 ok $output and note $output;
 ok(Hoge->no_fk_output);
-ok(Hoge->translate_to('HTML'));
+ok(Hoge->translate_to('HTML')) or diag(Hoge->translator->error);
 
 like(Fuga->output, qr/player/ms);
 unlike(Fuga->output, qr/user_purchase/ms);


### PR DESCRIPTION
SQL::Translator::Producer::HTML is required CGI.pm.
But, CGI.pm is remove from core module on perl 5.22.